### PR TITLE
Open symbolic link target rather than the link itself

### DIFF
--- a/cot
+++ b/cot
@@ -180,7 +180,7 @@ def main(args, stdin):
     # create document
     if args.file:
         # open file
-        path = os.path.abspath(args.file.name)
+        path = os.path.realpath(args.file.name)
         app.open(path)
 
     elif stdin:


### PR DESCRIPTION
cot コマンドでシンボリックリンクを開こうとするとエラーになっていましたが、リンク先を開くようにしてみました。
（open コマンドでは開けるのに cot コマンドでは開けなかった）
