### PR TITLE
cot doesn't open a file.

### DIFF
--- a/cot
+++ b/cot
@@ -243,7 +243,7 @@ def parse_args():
     # check file existance and create if needed
     if args.files:
         open_mode = 'r'
-        args.files = map(os.path.realpath, args.files)  # strip symlink
+        args.files = list(map(os.path.realpath, args.files))  # strip symlink
         if args.new and not os.path.exists(args.files[0]):
             open_mode = 'w'   # overwrite mode to create new file
             # create directory if not exists yet


### PR DESCRIPTION
# Description

The CLI cot doesn't open a file which is already exists.

# Environment and steps to reproduce

mac 10.12.3 (Sierra)
python 3.5.1
cot 2.5.0

1. open terminal.app.
2. enter commands below.

```bash
echo "test file" > test.txt
cot test.txt
```

# Result

Mac just focused to CotEditor but it doesn't open the `test.txt` file.

# Expected result

Mac focused to CotEditor and open the file.

# Discussion

In the python script `cot`, args.files which holds full path to given files is used in some for loops. The function `map()` returns map object which can be iterated just once. So I propose a solution like below.
