### PR TITLE
Allow creating new files without the -n flag

### DIFF
--- a/cot
+++ b/cot
@@ -272,23 +272,22 @@ def parse_args():
     # create a flag specifying if create a new blank window or file
     args.new_window = args.new and not args.files
 
-    # check file existance and create if needed
+    # check file existence and create if needed
     if args.files:
-        open_mode = 'r'
         args.files = list(map(os.path.realpath, args.files))  # strip symlink
-        if args.new and not os.path.exists(args.files[0]):
-            open_mode = 'w'   # overwrite mode to create new file
-            # create directory if not exists yet
-            filepath = args.files[0]
-            dirpath = os.path.dirname(filepath)
-            if dirpath:
-                try:
-                    os.makedirs(dirpath)
-                except OSError as err:  # guard against race condition
-                    if err.errno != errno.EEXIST:
-                        parser.error("argument FILE: {}".format(err))
-        # check readability or create new one
         for path in args.files:
+            open_mode = 'r'
+            if args.new or not os.path.exists(path):
+                open_mode = 'w'   # overwrite mode to create new file
+                # create directory if not exists yet
+                dirpath = os.path.dirname(path)
+                if dirpath:
+                    try:
+                        os.makedirs(dirpath)
+                    except OSError as err:  # guard against race condition
+                        if err.errno != errno.EEXIST:
+                            parser.error("argument FILE: {}".format(err))
+            # check readability or create new one
             try:
                 open(path, open_mode).close()
             except IOError as err:


### PR DESCRIPTION
Suggesting to make the `-n` flag optional, to closer match the behaviour of the `code` CLI command of VS Code. This allows creating new files with fewer keystrokes.

Additionally, tweaked the code so that multiple new files could be created at once:

```bash
$ ls
$ cot new1.md new2.md
$ ls
new1.md new2.md
```

The new CLI interface allows mixing existing and new file paths. Existing files won't be overridden, unless the `-n` flag is passed.